### PR TITLE
refactor: MCPサーバーのdesign_docs残存をbyebye_docsに統一

### DIFF
--- a/.agent/constraints.yaml
+++ b/.agent/constraints.yaml
@@ -113,7 +113,7 @@ roles:
   architect:
     permissions:
       read: [all]
-      write: [docs, design_docs]
+      write: [docs, agent_docs]
       propose: [architecture_changes]
     restrictions:
       - final_decision_by_human

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -71,7 +71,7 @@ pip install -e .
         "byebye-docs"
       ],
       "env": {
-        "DESIGN_DOCS_PROJECT_PATH": "."
+        "BYEBYE_DOCS_PROJECT_PATH": "."
       }
     }
   }
@@ -82,7 +82,7 @@ pip install -e .
 
 | 変数名 | 説明 | デフォルト |
 |--------|------|-----------|
-| `DESIGN_DOCS_PROJECT_PATH` | 対象プロジェクトのルートパス | カレントディレクトリ |
+| `BYEBYE_DOCS_PROJECT_PATH` | 対象プロジェクトのルートパス | カレントディレクトリ |
 
 ## 使用例
 

--- a/mcp-server/byebye_docs_mcp/__init__.py
+++ b/mcp-server/byebye_docs_mcp/__init__.py
@@ -1,0 +1,6 @@
+"""Byebye Docs MCP Server - MCP server for AI-first development design document templates."""
+
+from byebye_docs_mcp.server import main
+
+__version__ = "0.1.0"
+__all__ = ["main"]

--- a/mcp-server/byebye_docs_mcp/__main__.py
+++ b/mcp-server/byebye_docs_mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running the Byebye Docs MCP server as a module."""
+
+from byebye_docs_mcp.server import main
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/byebye_docs_mcp/server.py
+++ b/mcp-server/byebye_docs_mcp/server.py
@@ -1,4 +1,4 @@
-"""Design Docs MCP Server implementation."""
+"""Byebye Docs MCP Server implementation."""
 
 import json
 import os
@@ -92,7 +92,7 @@ DOCUMENT_SCHEMAS = {
 
 def get_project_root() -> Path:
     """Get the project root directory from environment or current directory."""
-    env_path = os.environ.get("DESIGN_DOCS_PROJECT_PATH")
+    env_path = os.environ.get("BYEBYE_DOCS_PROJECT_PATH")
     if env_path:
         return Path(env_path)
     return Path.cwd()

--- a/mcp-server/design_docs_mcp/__init__.py
+++ b/mcp-server/design_docs_mcp/__init__.py
@@ -1,6 +1,0 @@
-"""Design Docs MCP Server - MCP server for AI-first development design document templates."""
-
-from design_docs_mcp.server import main
-
-__version__ = "0.1.0"
-__all__ = ["main"]

--- a/mcp-server/design_docs_mcp/__main__.py
+++ b/mcp-server/design_docs_mcp/__main__.py
@@ -1,6 +1,0 @@
-"""Entry point for running the Design Docs MCP server as a module."""
-
-from design_docs_mcp.server import main
-
-if __name__ == "__main__":
-    main()

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    { name = "Design Docs MCP Team" }
+    { name = "Byebye Docs Team" }
 ]
 keywords = ["mcp", "ai", "byebye-docs", "templates", "claude"]
 classifiers = [
@@ -37,10 +37,10 @@ dev = [
 ]
 
 [project.scripts]
-byebye-docs = "design_docs_mcp:main"
+byebye-docs = "byebye_docs_mcp:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["design_docs_mcp"]
+packages = ["byebye_docs_mcp"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
- design_docs_mcp → byebye_docs_mcp にディレクトリ名変更
- 環境変数 DESIGN_DOCS_PROJECT_PATH → BYEBYE_DOCS_PROJECT_PATH
- pyproject.toml の author/packages を更新
- constraints.yaml の design_docs → agent_docs に変更